### PR TITLE
Fixing plural mob reference

### DIFF
--- a/main.py
+++ b/main.py
@@ -34,7 +34,7 @@ Be careful! Many perils await.
         "chicken", "horse", "cow", "sheep", "seahorse", "pig"
     ]
     pluralNiceMobNames = [
-        "chickens", "horses", "cows", "sheep", "seahorses", "sheep"
+        "chickens", "horses", "cows", "sheep", "seahorses", "pigs"
     ]
     colors = ["purple", "rainbow", "gray", "brown", "white", "green"]
 


### PR DESCRIPTION
"sheep" was repeated twice in the plural mob list, missing a reference to "pigs"